### PR TITLE
[WIP] refactor: generalize `Aggregator`

### DIFF
--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -360,11 +360,11 @@ impl Aggregator {
             <ISTaskProcessor as TaskProcessor>::TaskResponse,
         >,
     ) -> Result<(), AggregatorError> {
-        let task_index = signed_task_response.task_response.referenceTaskIndex;
+        let task_index = signed_task_response.task_response().referenceTaskIndex;
 
         let task_response_digest = self
             .tp
-            .hash_task_response(&signed_task_response.task_response);
+            .hash_task_response(&signed_task_response.task_response());
 
         let response =
             check_double_mapping(&self.tasks_responses, task_index, task_response_digest);
@@ -373,7 +373,7 @@ impl Aggregator {
             let mut inner_map = HashMap::new();
             inner_map.insert(
                 task_response_digest,
-                signed_task_response.clone().task_response,
+                signed_task_response.task_response().clone(),
             );
             self.tasks_responses.insert(task_index, inner_map);
         }

--- a/crates/aggregator/src/rpc_server.rs
+++ b/crates/aggregator/src/rpc_server.rs
@@ -10,8 +10,7 @@ pub type SignedTaskResponse = SignedTaskResponseImpl<TaskResponse>;
 /// Signed Task Response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignedTaskResponseImpl<T> {
-    /// Task Response
-    pub task_response: T,
+    task_response: T,
     signature: Signature,
     operator_id: OperatorId,
 }
@@ -34,5 +33,10 @@ impl<T: Serialize + for<'de> Deserialize<'de>> SignedTaskResponseImpl<T> {
     /// [`OperatorId`]
     pub fn operator_id(&self) -> OperatorId {
         self.operator_id
+    }
+
+    /// [`TaskResponse`]
+    pub fn task_response(&self) -> &T {
+        &self.task_response
     }
 }

--- a/crates/aggregator/src/rpc_server.rs
+++ b/crates/aggregator/src/rpc_server.rs
@@ -2,23 +2,23 @@ use eigen_crypto_bls::Signature;
 use eigen_types::operator::OperatorId;
 use incredible_bindings::incrediblesquaringtaskmanager::IIncredibleSquaringTaskManager::TaskResponse;
 use serde::{Deserialize, Serialize};
-// use alloy::sol_types::SolCall;
+// use alloy::sol_types::SolCall;x
+
+/// Signed Task Response
+pub type SignedTaskResponse = SignedTaskResponseImpl<TaskResponse>;
+
 /// Signed Task Response
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SignedTaskResponse {
+pub struct SignedTaskResponseImpl<T> {
     /// Task Response
-    pub task_response: TaskResponse,
+    pub task_response: T,
     signature: Signature,
     operator_id: OperatorId,
 }
 
-impl SignedTaskResponse {
+impl<T: Serialize + for<'de> Deserialize<'de>> SignedTaskResponseImpl<T> {
     /// Create a new [`SignedTaskResponse`]
-    pub fn new(
-        task_response: TaskResponse,
-        bls_signature: Signature,
-        operator_id: OperatorId,
-    ) -> Self {
+    pub fn new(task_response: T, bls_signature: Signature, operator_id: OperatorId) -> Self {
         Self {
             task_response,
             signature: bls_signature,


### PR DESCRIPTION
DO NOT MERGE

The goal of this PR is abstracting the tasks and responses received by the aggregator, in order to make it general enough that other AVSs could use it. If successful, it could be later moved to the SDK, or another repo.