### PR TITLE
fix: set `optimizer` option in foundry.toml

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -5,6 +5,7 @@ libs = ["lib"]
 fs_permissions = [{ access = "read-write", path = "./" }]
 solc = "0.8.26"
 via-ir = true
+optimizer = true
 
 remappings = [
     "@eigenlayer/=lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/",


### PR DESCRIPTION
`optimizer` default was changed to `false` some time back, so this PR manually sets it back. Doing this saves us some contract size, which was the cause of failure to deploy contracts with newer foundry versions.