### PR TITLE
refactor: remove warnings in tests and contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
+ "alloy-node-bindings",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
@@ -307,6 +308,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-node-bindings"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4520cd4bc5cec20c32c98e4bc38914c7fb96bf4a712105e44da186a54e65e3ba"
+dependencies = [
+ "alloy-genesis",
+ "alloy-primitives",
+ "k256",
+ "rand",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.7",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,10 +364,14 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -449,6 +471,18 @@ checksum = "9383845dd924939e7ab0298bbfe231505e20928907d7905aa3bf112287305e06"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11495cb8c8d3141fc27556a4c9188b81531ad5ec3076a0394c61a6dcfbce9f34"
+dependencies = [
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -4332,6 +4366,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "integration-tests"
+version = "0.0.1-alpha"
+dependencies = [
+ "alloy",
+ "eigen-utils",
+ "eigensdk",
+ "eyre",
+ "incredible-aggregator",
+ "incredible-bindings",
+ "incredible-challenger",
+ "incredible-config",
+ "incredible-operator",
+ "incredible-operator-2",
+ "incredible-squaring-avs",
+ "incredible-task-generator",
+ "incredible-testing-utils",
+ "rust-bls-bn254 0.1.0",
+ "serial_test",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "interprocess"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6381,6 +6438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6439,6 +6505,12 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "sec1"
@@ -6618,6 +6690,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,18 @@
 [workspace]
-members = ["crates/aggregator",
-"crates/operator",
-"bin/incredible-squaring-avs",
-"crates/cli",
-"crates/config",
-"crates/bindings",
-"crates/avs",
-"crates/challenger",
-"crates/chainio",
-"crates/testing-utils",
-"crates/task_generator",
-"crates/operator_2"
+members = [
+  "crates/aggregator",
+  "crates/operator",
+  "bin/incredible-squaring-avs",
+  "crates/cli",
+  "crates/config",
+  "crates/bindings",
+  "crates/avs",
+  "crates/challenger",
+  "crates/chainio",
+  "crates/testing-utils",
+  "crates/task_generator",
+  "crates/operator_2",
+  "integration-tests"
 ]
 
 resolver = "2"

--- a/contracts/script/OperatorDirectedPayments.s.sol
+++ b/contracts/script/OperatorDirectedPayments.s.sol
@@ -35,11 +35,7 @@ contract OperatorDirectedPayments is Script {
 
         string memory json = vm.readFile(filePath);
         uint32 duration = uint32(json.readUint(".duration"));
-        uint32 index_to_prove = uint32(json.readUint(".indexToProve"));
         uint256 num_payments = json.readUint(".numPayments");
-        address recipient = json.readAddress(".recipient");
-        address[] memory earners = json.readAddressArray(".earners");
-        bytes32[] memory earner_token_roots = json.readBytes32Array(".earnerTokenRoots");
         uint32 start_time = uint32(previousDivisibleTimestamp(block.timestamp));
 
         IRewardsCoordinatorTypes.OperatorReward[] memory operator_reward =

--- a/contracts/script/SetupPayments.s.sol
+++ b/contracts/script/SetupPayments.s.sol
@@ -138,7 +138,6 @@ contract SetupPayments is Script {
             IRewardsCoordinator(coreDeployment.rewardsCoordinator),
             tokenLeaves,
             earnerLeaves,
-            incredibleSquaringDeployment.strategy,
             endTimestamp,
             numPayments,
             NUM_TOKEN_EARNINGS,

--- a/contracts/script/utils/CoreDeploymentLib.sol
+++ b/contracts/script/utils/CoreDeploymentLib.sol
@@ -191,7 +191,6 @@ library CoreDeploymentLib {
 
         address eigenPodImpl =
             address(new EigenPod(IETHPOSDeposit(ethPOSDeposit), IEigenPodManager(result.eigenPodManager), GENESIS_TIME));
-        address eigenPodBeaconImpl = address(new UpgradeableBeacon(eigenPodImpl));
         address baseStrategyImpl =
             address(new StrategyBase(IStrategyManager(result.strategyManager), IPauserRegistry(result.pauserRegistry)));
         /// TODO: PauserRegistry isn't upgradeable

--- a/contracts/script/utils/IncredibleSquaringDeploymentLib.sol
+++ b/contracts/script/utils/IncredibleSquaringDeploymentLib.sol
@@ -175,7 +175,6 @@ library IncredibleSquaringDeploymentLib {
             });
         }
         // // set to 0 for every quorum
-        uint96[] memory quorumsMinimumStake = new uint96[](numQuorums);
         IStakeRegistryTypes.StrategyParams[][] memory quorumsStrategyParams =
             new IStakeRegistryTypes.StrategyParams[][](numQuorums);
         for (uint256 i = 0; i < numQuorums; i++) {

--- a/contracts/script/utils/SetupPaymentsLib.sol
+++ b/contracts/script/utils/SetupPaymentsLib.sol
@@ -137,16 +137,14 @@ library SetupPaymentsLib {
         IRewardsCoordinator rewardsCoordinator,
         bytes32[] memory tokenLeaves,
         IRewardsCoordinator.EarnerTreeMerkleLeaf[] memory earnerLeaves,
-        address strategy,
         uint32 rewardsCalculationEndTimestamp,
         uint256 NUM_PAYMENTS,
         uint256 NUM_TOKEN_EARNINGS,
         string memory filePath
     ) internal {
         console.logBytes32(tokenLeaves[0]);
-        bytes32 paymentRoot = createPaymentRoot(
-            rewardsCoordinator, tokenLeaves, earnerLeaves, NUM_PAYMENTS, NUM_TOKEN_EARNINGS, strategy, filePath
-        );
+        bytes32 paymentRoot =
+            createPaymentRoot(rewardsCoordinator, tokenLeaves, earnerLeaves, NUM_PAYMENTS, NUM_TOKEN_EARNINGS, filePath);
         rewardsCoordinator.submitRoot(paymentRoot, rewardsCalculationEndTimestamp);
     }
 
@@ -156,7 +154,6 @@ library SetupPaymentsLib {
         IRewardsCoordinator.EarnerTreeMerkleLeaf[] memory earnerLeaves,
         uint256 NUM_PAYMENTS,
         uint256 NUM_TOKEN_EARNINGS,
-        address strategy,
         string memory filePath
     ) internal returns (bytes32) {
         require(earnerLeaves.length == NUM_PAYMENTS, "Number of earners must match number of payments");
@@ -173,6 +170,7 @@ library SetupPaymentsLib {
 
     function createEarnerLeaves(address[] calldata earners, bytes32[] memory tokenLeaves)
         public
+        pure
         returns (IRewardsCoordinator.EarnerTreeMerkleLeaf[] memory)
     {
         IRewardsCoordinator.EarnerTreeMerkleLeaf[] memory leaves =
@@ -195,7 +193,7 @@ library SetupPaymentsLib {
         uint256 NUM_TOKEN_EARNINGS,
         uint256 TOKEN_EARNINGS,
         address strategy
-    ) internal returns (bytes32[] memory) {
+    ) internal view returns (bytes32[] memory) {
         bytes32[] memory leaves = new bytes32[](NUM_TOKEN_EARNINGS);
         for (uint256 i = 0; i < NUM_TOKEN_EARNINGS; i++) {
             IRewardsCoordinator.TokenTreeMerkleLeaf memory leaf = defaultTokenLeaf(TOKEN_EARNINGS, strategy);
@@ -225,7 +223,7 @@ library SetupPaymentsLib {
         vm.writeJson(finalJson, filePath);
     }
 
-    function parseLeavesFromJson(string memory filePath) internal returns (PaymentLeaves memory) {
+    function parseLeavesFromJson(string memory filePath) internal view returns (PaymentLeaves memory) {
         string memory json = vm.readFile(filePath);
         bytes memory data = vm.parseJson(json);
         return abi.decode(data, (PaymentLeaves));

--- a/contracts/test/IncredibleSquaringServiceManager.t.sol
+++ b/contracts/test/IncredibleSquaringServiceManager.t.sol
@@ -80,19 +80,19 @@ contract IncredibleSquaringServiceManagerSetup is Test {
     }
 
     function labelContracts(
-        CoreDeploymentLib.DeploymentData memory coreDeployment,
-        IncredibleSquaringDeploymentLib.DeploymentData memory incredibleSquaringDeployment
+        CoreDeploymentLib.DeploymentData memory coreDeploymentData,
+        IncredibleSquaringDeploymentLib.DeploymentData memory incredibleSquaringDeploymentData
     ) internal {
-        vm.label(coreDeployment.delegationManager, "DelegationManager");
-        vm.label(coreDeployment.avsDirectory, "AVSDirectory");
-        vm.label(coreDeployment.strategyManager, "StrategyManager");
-        vm.label(coreDeployment.eigenPodManager, "EigenPodManager");
-        vm.label(coreDeployment.rewardsCoordinator, "RewardsCoordinator");
-        vm.label(coreDeployment.eigenPodBeacon, "EigenPodBeacon");
-        vm.label(coreDeployment.pauserRegistry, "PauserRegistry");
-        vm.label(coreDeployment.strategyFactory, "StrategyFactory");
-        vm.label(coreDeployment.strategyBeacon, "StrategyBeacon");
-        vm.label(incredibleSquaringDeployment.incredibleSquaringServiceManager, "IncredibleSquaringServiceManager");
-        vm.label(incredibleSquaringDeployment.stakeRegistry, "StakeRegistry");
+        vm.label(coreDeploymentData.delegationManager, "DelegationManager");
+        vm.label(coreDeploymentData.avsDirectory, "AVSDirectory");
+        vm.label(coreDeploymentData.strategyManager, "StrategyManager");
+        vm.label(coreDeploymentData.eigenPodManager, "EigenPodManager");
+        vm.label(coreDeploymentData.rewardsCoordinator, "RewardsCoordinator");
+        vm.label(coreDeploymentData.eigenPodBeacon, "EigenPodBeacon");
+        vm.label(coreDeploymentData.pauserRegistry, "PauserRegistry");
+        vm.label(coreDeploymentData.strategyFactory, "StrategyFactory");
+        vm.label(coreDeploymentData.strategyBeacon, "StrategyBeacon");
+        vm.label(incredibleSquaringDeploymentData.incredibleSquaringServiceManager, "IncredibleSquaringServiceManager");
+        vm.label(incredibleSquaringDeploymentData.stakeRegistry, "StakeRegistry");
     }
 }

--- a/contracts/test/IncredibleSquaringServiceManager.t.sol
+++ b/contracts/test/IncredibleSquaringServiceManager.t.sol
@@ -49,8 +49,6 @@ contract IncredibleSquaringServiceManagerSetup is Test {
     function setUp() public virtual {
         deployer = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
         vm.label(deployer, "Deployer");
-        Vm.Wallet memory AGGREGATOR_ADDR = vm.createWallet("AGGREGATOR_AGGR");
-        Vm.Wallet memory TASK_GENERATOR_ADDR = vm.createWallet("TASK_GENERATOR_ADDR");
         Vm.Wallet memory ADMIN = vm.createWallet("ADMIN");
         address proxyAdmin = UpgradeableProxyLib.deployProxyAdmin();
 

--- a/contracts/test/SetupPaymentsLib.t.sol
+++ b/contracts/test/SetupPaymentsLib.t.sol
@@ -1,5 +1,5 @@
-// // SPDX-License-Identifier: UNLICENSED
-// pragma solidity ^0.8.12;
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.12;
 
 // import "forge-std/Test.sol";
 // import "../script/utils/SetupPaymentsLib.sol";

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -27,5 +27,3 @@ eyre = "0.6.12"
 incredible-squaring-avs = {path = "../bin/incredible-squaring-avs/"}
 serial_test = "3.1.1"
 rust-bls-bn254 = {git = "https://github.com/Layr-Labs/rust-bls-bn254.git", rev = "be3ef87", features = ["std"] }
-
-[workspace]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -135,7 +135,7 @@ mod tests {
         }
 
         incredible_config.set_sig_expiry(expiry.to_string());
-        let _ = register_operator_with_el_and_deposit_tokens_in_strategy(
+        register_operator_with_el_and_deposit_tokens_in_strategy(
             "metadata".to_string(),
             0, // allocation delay
             operator_pvt_key,
@@ -220,7 +220,7 @@ mod tests {
         )
         .await
         .unwrap();
-    
+
         let keystore = Keystore::from_file(&incredible_config.bls_keystore_path())
             .unwrap()
             .decrypt(&incredible_config.bls_keystore_password())
@@ -247,8 +247,8 @@ mod tests {
             .await
             .unwrap();
 
-        let _ = tokio::spawn(async move {
-            let _ = operator_builder.start_operator().await;
+        tokio::spawn(async move {
+            operator_builder.start_operator().await.unwrap();
         });
 
         let aggregator = Aggregator::new(incredible_config.clone()).await.unwrap();
@@ -257,7 +257,7 @@ mod tests {
         let arc_agg_clone = Arc::clone(&arc_agg);
 
         // Run process_tasks in a separate thread
-        let _ = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             tokio::runtime::Runtime::new().unwrap().block_on(async {
                 if let Err(e) =
                     Aggregator::process_tasks("ws://localhost:8545".to_string(), arc_agg_clone)
@@ -269,7 +269,7 @@ mod tests {
         });
 
         // Run the server in a separate thread
-        let _ = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             tokio::runtime::Runtime::new().unwrap().block_on(async {
                 if let Err(e) = Aggregator::start_server(
                     Arc::clone(&arc_agg),
@@ -290,7 +290,10 @@ mod tests {
             "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".to_string(),
             incredible_config.quorum_number().unwrap().to_string(),
         );
-        let _ = task_generator.create_new_task("2".parse().unwrap()).await;
+        task_generator
+            .create_new_task("2".parse().unwrap())
+            .await
+            .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 
         let task_manager_contract = IncredibleSquaringTaskManager::new(
@@ -329,7 +332,7 @@ mod tests {
             .unwrap()
             ._0;
 
-        assert_eq!(is_challenge_success, false);
+        assert!(!is_challenge_success);
     }
 
     async fn test_incredible_squaring_with_challenger() {
@@ -410,14 +413,14 @@ mod tests {
         )
         .await
         .unwrap();
-    
+
         let keystore = Keystore::from_file(&incredible_config.bls_keystore_2_path())
             .unwrap()
             .decrypt(&incredible_config.bls_keystore_2_password())
             .unwrap();
         let fr_key: String = keystore.iter().map(|&value| value as char).collect();
         let key_pair = BlsKeyPair::new(fr_key).unwrap();
-        let _ = register_for_operator_sets(
+        register_for_operator_sets(
             incredible_config.operator_set_id().unwrap(),
             key_pair,
             incredible_config.permission_controller_address().unwrap(),
@@ -441,8 +444,8 @@ mod tests {
             .await
             .unwrap();
 
-        let _ = tokio::spawn(async move {
-            let _ = operator_builder.start_operator().await;
+        tokio::spawn(async move {
+            operator_builder.start_operator().await.unwrap();
         });
 
         let aggregator = Aggregator::new(incredible_config.clone()).await.unwrap();
@@ -451,7 +454,7 @@ mod tests {
         let arc_agg_clone = Arc::clone(&arc_agg);
 
         // Run process_tasks in a separate thread
-        let _ = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             tokio::runtime::Runtime::new().unwrap().block_on(async {
                 if let Err(e) =
                     Aggregator::process_tasks("ws://localhost:8545".to_string(), arc_agg_clone)
@@ -463,7 +466,7 @@ mod tests {
         });
 
         // Run the server in a separate thread
-        let _ = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             tokio::runtime::Runtime::new().unwrap().block_on(async {
                 if let Err(e) = Aggregator::start_server(
                     Arc::clone(&arc_agg),
@@ -479,8 +482,8 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
         let mut challenger = Challenger::build(incredible_config.clone()).await.unwrap();
-        let _ = tokio::spawn(async move {
-            let _ = challenger.start_challenger().await;
+        tokio::spawn(async move {
+            challenger.start_challenger().await.unwrap();
         });
 
         let task_generator = incredible_task_generator::TaskManager::new(
@@ -489,7 +492,10 @@ mod tests {
             "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".to_string(),
             incredible_config.quorum_number().unwrap().to_string(),
         );
-        let _ = task_generator.create_new_task("2".parse().unwrap()).await;
+        task_generator
+            .create_new_task("2".parse().unwrap())
+            .await
+            .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 
         let task_manager_contract = IncredibleSquaringTaskManager::new(
@@ -528,7 +534,7 @@ mod tests {
             .unwrap()
             ._0;
 
-        assert_eq!(is_challenge_success, true);
+        assert!(is_challenge_success);
     }
 
     #[tokio::test]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -2,9 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use alloy::primitives::{address, FixedBytes, U256};
-    use eigen_utils::slashing::sdk::mockerc20::MockERC20;
+    use alloy::primitives::{FixedBytes, U256};
     use eigensdk::common::get_provider;
     use eigensdk::crypto_bls::BlsKeyPair;
     use eigensdk::logging::{init_logger, log_level::LogLevel};
@@ -30,10 +28,7 @@ mod tests {
         get_incredible_squaring_strategy_address, get_incredible_squaring_task_manager,
     };
     use rust_bls_bn254::keystores::base_keystore::Keystore;
-    use serial_test::serial;
-    use std::str::FromStr;
     use std::{
-        process::Stdio,
         sync::Arc,
         time::{SystemTime, UNIX_EPOCH},
     };
@@ -223,7 +218,9 @@ mod tests {
             [get_incredible_squaring_strategy_address().await].to_vec(),
             [100].to_vec(),
         )
-        .await;
+        .await
+        .unwrap();
+    
         let keystore = Keystore::from_file(&incredible_config.bls_keystore_path())
             .unwrap()
             .decrypt(&incredible_config.bls_keystore_password())
@@ -418,7 +415,7 @@ mod tests {
             .unwrap();
         let fr_key: String = keystore.iter().map(|&value| value as char).collect();
         let key_pair = BlsKeyPair::new(fr_key).unwrap();
-        let e = register_for_operator_sets(
+        let _ = register_for_operator_sets(
             incredible_config.operator_set_id().unwrap(),
             key_pair,
             incredible_config.permission_controller_address().unwrap(),
@@ -480,7 +477,7 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
         let mut challenger = Challenger::build(incredible_config.clone()).await.unwrap();
-        let c_handle = tokio::spawn(async move {
+        let _ = tokio::spawn(async move {
             let _ = challenger.start_challenger().await;
         });
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -408,7 +408,9 @@ mod tests {
             [get_incredible_squaring_strategy_address().await].to_vec(),
             [100].to_vec(),
         )
-        .await;
+        .await
+        .unwrap();
+    
         let keystore = Keystore::from_file(&incredible_config.bls_keystore_2_path())
             .unwrap()
             .decrypt(&incredible_config.bls_keystore_2_password())


### PR DESCRIPTION
This PR fixes warnings in [integration-test/lib.rs](https://github.com/Layr-Labs/incredible-squaring-avs-rs/blob/master/integration-tests/src/lib.rs) and contracts when running `forge build.` We still have some warnings, but they are from `eigenlayer-middleware`.

```
➜  contracts git:(refactor/contracts-warnings) ✗ forge clean && forge build
[⠊] Compiling...
[⠔] Compiling 178 files with Solc 0.8.27
[⠑] Solc 0.8.27 finished in 46.52s
Compiler run successful with warnings:
Warning (8760): This declaration has the same name as another declaration.
  --> lib/eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol:49:9:
   |
49 |         IECDSAStakeRegistryTypes.Quorum memory quorum
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> lib/eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol:133:5:
    |
133 |     function quorum() external view returns (IECDSAStakeRegistryTypes.Quorum memory) {
    |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (8760): This declaration has the same name as another declaration.
  --> lib/eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol:59:9:
   |
59 |         IECDSAStakeRegistryTypes.Quorum memory quorum
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> lib/eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol:133:5:
    |
133 |     function quorum() external view returns (IECDSAStakeRegistryTypes.Quorum memory) {
    |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (8760): This declaration has the same name as another declaration.
  --> lib/eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol:99:9:
   |
99 |         IECDSAStakeRegistryTypes.Quorum memory quorum,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> lib/eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol:133:5:
    |
133 |     function quorum() external view returns (IECDSAStakeRegistryTypes.Quorum memory) {
    |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (8760): This declaration has the same name as another declaration.
   --> lib/eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol:393:9:
    |
393 |         IECDSAStakeRegistryTypes.Quorum memory quorum
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> lib/eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol:133:5:
    |
133 |     function quorum() external view returns (IECDSAStakeRegistryTypes.Quorum memory) {
    |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (8760): This declaration has the same name as another declaration.
   --> lib/eigenlayer-middleware/test/mocks/DelegationMock.sol:264:46:
    |
264 |     function setIsOperator(address operator, bool isOperator) external {
    |                                              ^^^^^^^^^^^^^^^
Note: The other declaration is here:
   --> lib/eigenlayer-middleware/test/mocks/DelegationMock.sol:268:5:
    |
268 |     function isOperator(
    |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (5667): Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/eigenlayer-middleware/src/RegistryCoordinator.sol:186:9:
    |
186 |         bytes32 operatorId,
    |         ^^^^^^^^^^^^^^^^^^

Warning (5667): Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/eigenlayer-middleware/src/RegistryCoordinator.sol:187:9:
    |
187 |         bytes memory quorumNumbers,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^

Warning (5667): Unused function parameter. Remove or comment out the variable name to silence this warning.
  --> lib/eigenlayer-middleware/test/harnesses/RegistryCoordinatorHarness.t.sol:50:9:
   |
50 |         SignatureWithSaltAndExpiry memory operatorSignature
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Warning (2018): Function state mutability can be restricted to pure
   --> lib/eigenlayer-middleware/test/mocks/DelegationMock.sol:285:5:
    |
285 |     function minWithdrawalDelayBlocks() external view override returns (uint32) {
    |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to view
  --> lib/eigenlayer-middleware/test/mocks/PermissionControllerMock.sol:79:5:
   |
79 |     function canCall(
   |     ^ (Relevant source part starts here and spans across multiple lines).
```