### PR TITLE
ci: remove llvm-coverage from CI and improve Makefile

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,7 +78,7 @@ jobs:
       - name: docker
         uses: docker-practice/actions-setup-docker@master
       - name: Run unit tests
-        run: make pr
+        run: make tests
 
       - name: Run Integration tests
         run: make integration_tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,11 +61,6 @@ jobs:
       - name: Install nightly Rust
         run: rustup toolchain install nightly
 
-      - name: Install testing tools
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,15 @@ start_docker:
 		ghcr.io/foundry-rs/foundry:latest --host 0.0.0.0
 	sleep 2
 
-pr: 
+tests:
 	$(MAKE) start_docker
 	$(MAKE) deploy-el-and-avs-contracts
 	cargo test --workspace --exclude incredible-bindings
+
+pr:
+	$(MAKE) tests
+	$(MAKE) clippy
+	cargo fmt -- --check
 
 clippy:
 	cargo clippy --workspace --lib --examples --tests --benches --all-features --exclude incredible-bindings

--- a/Makefile
+++ b/Makefile
@@ -31,16 +31,14 @@ pr:
 	$(MAKE) start_docker
 	$(MAKE) deploy-el-and-avs-contracts
 	cargo test --workspace --exclude incredible-bindings
-	cargo clippy --workspace --lib --examples --tests --benches --all-features --exclude incredible-bindings
-	cargo fmt -- --check
 
 clippy:
-	   cargo clippy --workspace --lib --examples --tests --benches --all-features --exclude incredible-bindings
+	cargo clippy --workspace --lib --examples --tests --benches --all-features --exclude incredible-bindings
 
 integration_tests:
-				  $(MAKE) start_docker
-				  $(MAKE) deploy-el-and-avs-contracts
-				  cargo test  --manifest-path ./integration-tests/Cargo.toml  -- --nocapture
+	$(MAKE) start_docker
+	$(MAKE) deploy-el-and-avs-contracts
+	cargo test  --manifest-path ./integration-tests/Cargo.toml  -- --nocapture
 
 fmt: 
 	cargo fmt


### PR DESCRIPTION
- Remove `llvm-cov` from CI since we aren’t using it.
- Remove `cargo clippy` and `cargo fmt` from the `make pr` rule since we are already running that in CI.