### PR TITLE
chore: use only `eigensdk` crate in `dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-avsregistry"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-elcontracts"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "eigen-common",
@@ -2452,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-eth"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-fireblocks"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "chrono",
@@ -2486,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "eigen-common"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "url",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "eigen-crypto-bls"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -2512,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "eigen-crypto-bn254"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",
@@ -2523,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "eigen-logging"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "ctor",
  "once_cell",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "eigen-metrics"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "eigen-logging",
  "metrics",
@@ -2545,7 +2545,7 @@ dependencies = [
 [[package]]
 name = "eigen-metrics-collectors-economic"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "eigen-client-avsregistry",
@@ -2560,7 +2560,7 @@ dependencies = [
 [[package]]
 name = "eigen-metrics-collectors-rpc-calls"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "eigen-logging",
  "metrics",
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "eigen-nodeapi"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "ntex",
  "serde",
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-avsregistry"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-blsaggregation"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-operatorsinfo"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "eigen-signer"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "eigen-testing-utils"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "eigen-common",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "eigen-types"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "eigen-utils"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "alloy",
  "regex",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "eigensdk"
 version = "0.4.0"
-source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13438a3c5b0cd6543ced084d8991ff7c7fd#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
+source = "git+https://github.com/Layr-Labs/eigensdk-rs?rev=7cfce13#7cfce13438a3c5b0cd6543ced084d8991ff7c7fd"
 dependencies = [
  "eigen-client-avsregistry",
  "eigen-client-elcontracts",
@@ -4094,8 +4094,6 @@ dependencies = [
  "ark-ec 0.5.0",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
- "eigen-types",
- "eigen-utils",
  "eigensdk",
  "eyre",
  "futures-util",
@@ -4155,8 +4153,6 @@ name = "incredible-chainio"
 version = "0.0.1-alpha"
 dependencies = [
  "alloy",
- "eigen-types",
- "eigen-utils",
  "eigensdk",
  "eyre",
  "futures-util",
@@ -4173,7 +4169,6 @@ name = "incredible-challenger"
 version = "0.0.1-alpha"
 dependencies = [
  "alloy",
- "eigen-utils",
  "eigensdk",
  "eyre",
  "futures-util",
@@ -4202,7 +4197,7 @@ version = "0.0.1-alpha"
 dependencies = [
  "alloy",
  "confy",
- "eigen-types",
+ "eigensdk",
  "hex",
  "incredible-testing-utils",
  "ruint",
@@ -4238,9 +4233,6 @@ dependencies = [
  "alloy",
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
- "eigen-metrics-collectors-rpc-calls",
- "eigen-types",
- "eigen-utils",
  "eigensdk",
  "eyre",
  "futures-util",
@@ -4268,9 +4260,6 @@ dependencies = [
  "alloy",
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
- "eigen-metrics-collectors-rpc-calls",
- "eigen-types",
- "eigen-utils",
  "eigensdk",
  "eyre",
  "futures-util",
@@ -4298,8 +4287,6 @@ version = "0.0.1-alpha"
 dependencies = [
  "alloy",
  "clap",
- "eigen-types",
- "eigen-utils",
  "eigensdk",
  "eyre",
  "hex",
@@ -4323,7 +4310,6 @@ name = "incredible-task-generator"
 version = "0.0.1-alpha"
 dependencies = [
  "alloy",
- "eigen-utils",
  "eigensdk",
  "eyre",
  "futures-util",
@@ -4341,7 +4327,6 @@ name = "incredible-testing-utils"
 version = "0.0.1-alpha"
 dependencies = [
  "alloy",
- "eigen-utils",
  "eigensdk",
  "tracing",
 ]
@@ -4397,7 +4382,6 @@ name = "integration-tests"
 version = "0.0.1-alpha"
 dependencies = [
  "alloy",
- "eigen-utils",
  "eigensdk",
  "eyre",
  "incredible-aggregator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,23 +76,6 @@ incredible-task-generator = { path = "crates/task_generator/" }
 incredible-operator-2 = { path = "crates/operator_2/", features = ["default"] }
 
 # eigensdk-rs 
-eigen-common = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-client-avsregistry = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-testing-utils = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-crypto-bls = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-types = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-metrics = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-utils = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-cli = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-logging = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-crypto-bn254 = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-client-elcontracts = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-services-operatorsinfo = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-services-avsregistry = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-services-blsaggregation = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-metrics-collectors-rpc-calls = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-client-eth = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigen-nodeapi = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd" }
-eigensdk = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13438a3c5b0cd6543ced084d8991ff7c7fd", features = [
+eigensdk = { git = "https://github.com/Layr-Labs/eigensdk-rs", rev = "7cfce13", features = [
   "full",
 ] }

--- a/bin/incredible-squaring-avs/Cargo.toml
+++ b/bin/incredible-squaring-avs/Cargo.toml
@@ -27,13 +27,12 @@ hex = "0.4"
 metrics-exporter-prometheus = "0.16"
 rust-bls-bn254.workspace = true
 metrics-util.workspace = true
+
 # eigensdk-rs
 eigensdk.workspace = true
-eigen-utils.workspace = true
-eigen-types.workspace = true
+
 [dev-dependencies]
 tokio.workspace = true
-
 
 [[bin]]
 name = "incredible-squaring-avs"

--- a/bin/incredible-squaring-avs/src/commands/avs/mod.rs
+++ b/bin/incredible-squaring-avs/src/commands/avs/mod.rs
@@ -5,10 +5,6 @@ use alloy::providers::Provider;
 use alloy::signers::local::{LocalSigner, PrivateKeySigner};
 use clap::value_parser;
 use clap::{Args, Parser};
-use eigen_types::operator::Operator;
-use eigen_utils::slashing::core::allocationmanager::AllocationManager::{self, OperatorSet};
-use eigen_utils::slashing::core::allocationmanager::IAllocationManagerTypes::AllocateParams;
-use eigen_utils::slashing::middleware::registrycoordinator::RegistryCoordinator;
 use eigensdk::client_elcontracts::reader::ELChainReader;
 use eigensdk::client_elcontracts::{error::ElContractsError, writer::ELChainWriter};
 use eigensdk::common::{get_provider, get_signer};
@@ -20,6 +16,12 @@ use eigensdk::testing_utils::anvil_constants::{
     get_permission_controller_address, get_rewards_coordinator_address,
     get_strategy_manager_address, ANVIL_HTTP_URL,
 };
+use eigensdk::types::operator::Operator;
+use eigensdk::utils::slashing::core::allocationmanager::AllocationManager::{self, OperatorSet};
+use eigensdk::utils::slashing::core::allocationmanager::IAllocationManagerTypes::AllocateParams;
+use eigensdk::utils::slashing::middleware::registrycoordinator::ISlashingRegistryCoordinatorTypes::OperatorSetParam;
+use eigensdk::utils::slashing::middleware::registrycoordinator::IStakeRegistryTypes::StrategyParams;
+use eigensdk::utils::slashing::middleware::registrycoordinator::RegistryCoordinator;
 use incredible_avs::builder::{AvsBuilder, DefaultAvsLauncher, LaunchAvs};
 use incredible_config::IncredibleConfig;
 use incredible_testing_utils::{
@@ -789,19 +791,16 @@ pub async fn create_total_delegated_stake_quorum(
     let registry_coordinator_instance =
         RegistryCoordinator::new(registry_coordinator_address, get_signer(&pvt_key, rpc_url));
 
-    let operator_set_param =
-        eigen_utils::slashing::middleware::registrycoordinator::ISlashingRegistryCoordinatorTypes::OperatorSetParam {
-            maxOperatorCount: 3,
-            kickBIPsOfOperatorStake: 100,
-            kickBIPsOfTotalStake: 1000,
-        };
+    let operator_set_param = OperatorSetParam {
+        maxOperatorCount: 3,
+        kickBIPsOfOperatorStake: 100,
+        kickBIPsOfTotalStake: 1000,
+    };
     let minimum_stake: U96 = U96::from(0);
-    let strategy_params = vec![
-        eigen_utils::slashing::middleware::registrycoordinator::IStakeRegistryTypes::StrategyParams {
-            strategy: strategy_address,
-            multiplier: U96::from(1),
-        },
-    ];
+    let strategy_params = vec![StrategyParams {
+        strategy: strategy_address,
+        multiplier: U96::from(1),
+    }];
     let s = registry_coordinator_instance
         .createTotalDelegatedStakeQuorum(operator_set_param, minimum_stake, strategy_params)
         .send()

--- a/crates/aggregator/Cargo.toml
+++ b/crates/aggregator/Cargo.toml
@@ -15,8 +15,6 @@ incredible-bindings.workspace = true
 ark-bn254.workspace = true
 ark-ec.workspace = true
 alloy.workspace = true
-eigensdk.workspace = true
-eigen-types.workspace = true
 serde.workspace = true
 ark-serialize = "0.4.2"
 hex = "0.4.3"
@@ -24,7 +22,6 @@ eyre.workspace = true
 incredible-chainio.workspace = true
 incredible-config.workspace = true
 incredible-metrics.workspace = true
-eigen-utils.workspace = true
 jsonrpc-core = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 tracing.workspace = true
@@ -32,6 +29,10 @@ tokio.workspace = true
 thiserror.workspace = true
 futures-util.workspace = true
 tokio-util = "0.7.11"
+
+# eigensdk-rs
+eigensdk.workspace = true
+
 [dev-dependencies]
 incredible-testing-utils.workspace = true
 toml.workspace = true

--- a/crates/aggregator/src/fake_aggregator.rs
+++ b/crates/aggregator/src/fake_aggregator.rs
@@ -3,7 +3,6 @@ use alloy::providers::Provider;
 use alloy::providers::{ProviderBuilder, WsConnect};
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
-use eigen_types::avs::TaskResponseDigest;
 use eigensdk::client_avsregistry::reader::AvsRegistryChainReader;
 use eigensdk::common::get_ws_provider;
 use eigensdk::crypto_bls::{convert_to_g1_point, convert_to_g2_point};
@@ -15,6 +14,7 @@ use eigensdk::services_blsaggregation::bls_agg::{
 use eigensdk::services_blsaggregation::bls_aggregation_service_error::BlsAggregationServiceError;
 use eigensdk::services_blsaggregation::bls_aggregation_service_response::BlsAggregationServiceResponse;
 use eigensdk::services_operatorsinfo::operatorsinfo_inmemory::OperatorInfoServiceInMemory;
+use eigensdk::types::avs::TaskResponseDigest;
 use futures_util::StreamExt;
 use incredible_bindings::incrediblesquaringtaskmanager::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;
 use incredible_bindings::incrediblesquaringtaskmanager::IIncredibleSquaringTaskManager::{

--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -12,7 +12,6 @@ use alloy::providers::{ProviderBuilder, WsConnect};
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
 use ark_ec::AffineRepr;
-use eigen_types::avs::TaskResponseDigest;
 use eigensdk::client_avsregistry::reader::AvsRegistryChainReader;
 use eigensdk::common::get_ws_provider;
 use eigensdk::crypto_bls::{convert_to_g1_point, convert_to_g2_point};
@@ -24,6 +23,7 @@ use eigensdk::services_blsaggregation::bls_agg::{
 use eigensdk::services_blsaggregation::bls_aggregation_service_error::BlsAggregationServiceError;
 use eigensdk::services_blsaggregation::bls_aggregation_service_response::BlsAggregationServiceResponse;
 use eigensdk::services_operatorsinfo::operatorsinfo_inmemory::OperatorInfoServiceInMemory;
+use eigensdk::types::avs::TaskResponseDigest;
 pub use error::AggregatorError;
 use futures_util::StreamExt;
 use incredible_bindings::incrediblesquaringtaskmanager::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;

--- a/crates/aggregator/src/rpc_server.rs
+++ b/crates/aggregator/src/rpc_server.rs
@@ -1,5 +1,5 @@
-use eigen_types::operator::OperatorId;
 use eigensdk::crypto_bls::Signature;
+use eigensdk::types::operator::OperatorId;
 use incredible_bindings::incrediblesquaringtaskmanager::IIncredibleSquaringTaskManager::TaskResponse;
 use serde::{Deserialize, Serialize};
 // use alloy::sol_types::SolCall;

--- a/crates/avs/Cargo.toml
+++ b/crates/avs/Cargo.toml
@@ -18,8 +18,9 @@ tracing.workspace = true
 metrics.workspace = true
 metrics-util.workspace = true
 
-
+# eigensdk-rs
 eigensdk.workspace = true
+
 #incredible
 incredible-operator-2.workspace = true
 incredible-config.workspace = true
@@ -28,6 +29,7 @@ incredible-challenger.workspace = true
 incredible-aggregator.workspace = true
 incredible-task-generator.workspace = true
 incredible-metrics.workspace = true
+
 #tokio
 tokio.workspace = true
 

--- a/crates/chainio/Cargo.toml
+++ b/crates/chainio/Cargo.toml
@@ -23,5 +23,3 @@ reqwest.workspace = true
 
 #eigensdk-rs
 eigensdk.workspace = true
-eigen-types.workspace = true
-eigen-utils.workspace = true

--- a/crates/chainio/src/lib.rs
+++ b/crates/chainio/src/lib.rs
@@ -9,8 +9,8 @@ use alloy::{
     primitives::{Address, U256},
     rpc::types::TransactionReceipt,
 };
-use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
 use eigensdk::common::{get_provider, get_signer};
+use eigensdk::types::operator::{QuorumNum, QuorumThresholdPercentage};
 use error::ChainIoError;
 use incredible_bindings::incrediblesquaringtaskmanager::IIncredibleSquaringTaskManager::{
     Task, TaskResponse, TaskResponseMetadata,

--- a/crates/challenger/Cargo.toml
+++ b/crates/challenger/Cargo.toml
@@ -26,6 +26,6 @@ incredible-chainio.workspace = true
 
 #eigensdk-rs
 eigensdk.workspace = true
-eigen-utils.workspace = true
+
 [dev-dependencies]
 incredible-task-generator.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -31,7 +31,7 @@ ruint = "1.12.3"
 
 
 #eigensdk-rs
-eigen-types.workspace = true
+eigensdk.workspace = true
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,7 +1,7 @@
 //! config
 use alloy::hex::FromHex;
 use alloy::primitives::{Address, Bytes, FixedBytes, U256};
-use eigen_types::operator::OperatorId;
+use eigensdk::types::operator::OperatorId;
 use error::ConfigError;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -17,11 +17,11 @@ thiserror.workspace = true
 incredible-bindings.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
+metrics.workspace = true
+metrics-util.workspace = true
 
 # eigen-rs
 eigensdk.workspace = true
-metrics.workspace = true
-metrics-util.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/operator/Cargo.toml
+++ b/crates/operator/Cargo.toml
@@ -19,10 +19,7 @@ eyre.workspace = true
 futures-util.workspace = true
 
 # eigensdk-rs
-eigen-types.workspace = true
 eigensdk.workspace = true
-eigen-metrics-collectors-rpc-calls.workspace = true
-eigen-utils.workspace = true
 
 
 rust-bls-bn254.workspace = true

--- a/crates/operator/src/builder.rs
+++ b/crates/operator/src/builder.rs
@@ -11,11 +11,11 @@ use alloy::{
 
 use alloy::primitives::U256;
 use alloy::providers::{Provider, ProviderBuilder};
-use eigen_types::operator::OperatorId;
 use eigensdk::client_avsregistry::reader::AvsRegistryChainReader;
 use eigensdk::client_eth::instrumented_client::InstrumentedClient;
 use eigensdk::crypto_bls::BlsKeyPair;
 use eigensdk::logging::get_logger;
+use eigensdk::types::operator::OperatorId;
 use eyre::Result;
 use futures_util::StreamExt;
 use incredible_aggregator::rpc_server::SignedTaskResponse;

--- a/crates/operator_2/Cargo.toml
+++ b/crates/operator_2/Cargo.toml
@@ -21,7 +21,6 @@ incredible-operator.workspace = true
 
 # eigensdk-rs
 eigensdk.workspace = true
-eigen-types.workspace = true
 
 rust-bls-bn254.workspace = true
 
@@ -36,8 +35,6 @@ serde_json.workspace = true
 toml.workspace = true
 tracing.workspace = true
 rand_core.workspace = true
-eigen-metrics-collectors-rpc-calls.workspace = true
-eigen-utils.workspace = true
 
 [dev-dependencies]
 incredible-testing-utils.workspace = true

--- a/crates/operator_2/src/builder.rs
+++ b/crates/operator_2/src/builder.rs
@@ -10,11 +10,11 @@ use incredible_operator::{client::ClientAggregator, error::OperatorError};
 
 use alloy::primitives::U256;
 use alloy::providers::{Provider, ProviderBuilder};
-use eigen_types::operator::OperatorId;
 use eigensdk::client_avsregistry::reader::AvsRegistryChainReader;
 use eigensdk::client_eth::instrumented_client::InstrumentedClient;
 use eigensdk::crypto_bls::BlsKeyPair;
 use eigensdk::logging::get_logger;
+use eigensdk::types::operator::OperatorId;
 use eyre::Result;
 use futures_util::StreamExt;
 use incredible_aggregator::rpc_server::SignedTaskResponse;

--- a/crates/task_generator/Cargo.toml
+++ b/crates/task_generator/Cargo.toml
@@ -29,5 +29,4 @@ reqwest.workspace = true
 
 # eigensdk-rs
 eigensdk.workspace = true
-eigen-utils.workspace = true
 

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -11,7 +11,8 @@ description = "eigen layer operator"
 workspace = true
 
 [dependencies]
-eigensdk.workspace = true
-eigen-utils.workspace = true
 alloy.workspace = true
 tracing.workspace = true
+
+# eigen-rs
+eigensdk.workspace = true

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,8 +10,6 @@ description = "integration tests for incredible avs"
 
 [dependencies]
 alloy = { version = "0.9", features = ["full","signer-keystore","node-bindings"] }
-eigensdk.workspace = true
-eigen-utils.workspace = true
 incredible-config = {path = "../crates/config/"}
 incredible-challenger = {path = "../crates/challenger/"}
 incredible-bindings = {path = "../crates/bindings/"}
@@ -21,6 +19,10 @@ incredible-operator = {path = "../crates/operator/" , features = ["integration_t
 incredible-operator-2 = {path = "../crates/operator_2/" , features = ["integration_tests"]}
 incredible-aggregator = {path = "../crates/aggregator/"}
 toml = "0.8"
+
+# eigen-rs
+eigensdk.workspace = true
+
 [dev-dependencies]
 tokio = { version = "1.21", default-features = false }
 eyre = "0.6.12"


### PR DESCRIPTION
This PR simplifies the `cargo.toml`, only using the `eigensdk` crate