### PR TITLE
test: set equivocation chance to 0 on operator tests

### DIFF
--- a/crates/operator/src/builder.rs
+++ b/crates/operator/src/builder.rs
@@ -260,11 +260,12 @@ mod tests {
                 .await
                 .to_string(),
         );
+        incredible_config.set_operator_1_times_failing("0".to_string());
         let operator_builder = OperatorBuilder::build(incredible_config).await.unwrap();
 
         let task_response = operator_builder.process_new_task(new_task_created);
 
-        assert_eq!(task_response.numberSquared, U256::from(28));
+        assert_eq!(task_response.numberSquared, U256::from(16));
         assert_eq!(task_response.referenceTaskIndex, 1u32);
     }
 

--- a/crates/operator_2/src/builder.rs
+++ b/crates/operator_2/src/builder.rs
@@ -259,6 +259,7 @@ mod tests {
                 .await
                 .to_string(),
         );
+        incredible_config.set_operator_2_times_failing("0".to_string());
         let operator_builder = OperatorBuilder::build(incredible_config, None)
             .await
             .unwrap();


### PR DESCRIPTION
This PR sets the `times_failing` parameter on both operators to 0, so test results are deterministic.