### PR TITLE
feat: parse RPC request and use different address for aggregator server

### DIFF
--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -34,6 +34,7 @@ use incredible_chainio::AvsWriter;
 use incredible_config::IncredibleConfig;
 use jsonrpsee::server::{RpcModule, Server};
 use jsonrpsee::types::ErrorObject;
+use rpc_server::RpcRequest;
 pub use rpc_server::SignedTaskResponse;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -199,26 +200,30 @@ impl Aggregator {
         // See https://github.com/paritytech/jsonrpsee/blob/42461391fee47c94d42c4a7303355525291df9f6/examples/examples/cors_server.rs
         let mut module = RpcModule::new((service_handle, task_responses));
         module
-            .register_async_method("process_signed_task_response", async |params, ctx, _| {
-                let (service_handle, task_responses) = ctx.as_ref();
-                let signed_task_response: SignedTaskResponse = params
-                    .one()
-                    .map_err(|err| ErrorObject::owned(0, err.to_string(), None::<()>))?;
+            .register_async_method(
+                "process_signed_task_response",
+                |params, ctx, _| async move {
+                    let (service_handle, task_responses) = ctx.as_ref();
+                    let signed_task_response = params
+                        .parse::<RpcRequest>()
+                        .map_err(|err| ErrorObject::owned(0, err.to_string(), None::<()>))?
+                        .params;
 
-                // Call the process_signed_task_response function
-                let mut task_responses_lock = task_responses.lock().await;
-                let result = Self::process_signed_task_response(
-                    signed_task_response,
-                    service_handle,
-                    &mut task_responses_lock,
-                )
-                .await;
+                    // Call the process_signed_task_response function
+                    let mut task_responses_lock = task_responses.lock().await;
+                    let result = Self::process_signed_task_response(
+                        signed_task_response,
+                        service_handle,
+                        &mut task_responses_lock,
+                    )
+                    .await;
 
-                match result {
-                    Ok(()) => Ok(true),
-                    Err(err) => Err(ErrorObject::owned(0, err.to_string(), None::<()>)),
-                }
-            })
+                    match result {
+                        Ok(()) => Ok(true),
+                        Err(err) => Err(ErrorObject::owned(0, err.to_string(), None::<()>)),
+                    }
+                },
+            )
             .expect("method name is unique");
         let socket: SocketAddr = port_address.parse().map_err(|e| {
             AggregatorError::IOError(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))

--- a/crates/aggregator/src/rpc_server.rs
+++ b/crates/aggregator/src/rpc_server.rs
@@ -12,6 +12,15 @@ pub struct SignedTaskResponse {
     operator_id: OperatorId,
 }
 
+/// RPC Request is used to parse the request from the RPC server
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RpcRequest {
+    id: u64,
+    jsonrpc: String,
+    /// Params of the request
+    pub params: SignedTaskResponse,
+}
+
 impl SignedTaskResponse {
     /// Create a new [`SignedTaskResponse`]
     pub fn new(

--- a/crates/aggregator/src/rpc_server.rs
+++ b/crates/aggregator/src/rpc_server.rs
@@ -15,8 +15,6 @@ pub struct SignedTaskResponse {
 /// RPC Request is used to parse the request from the RPC server
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RpcRequest {
-    id: u64,
-    jsonrpc: String,
     /// Params of the request
     pub params: SignedTaskResponse,
 }

--- a/crates/chainio/src/lib.rs
+++ b/crates/chainio/src/lib.rs
@@ -168,7 +168,7 @@ impl AvsWriter {
             .await?
             .get_receipt()
             .await?;
-        info!("receipt for response{:?}", receipt.transaction_hash);
+        info!("receipt for response: {:?}", receipt.transaction_hash);
 
         Ok(())
     }

--- a/crates/challenger/src/lib.rs
+++ b/crates/challenger/src/lib.rs
@@ -165,7 +165,7 @@ impl Challenger {
                         .unwrap()
                         .shares;
                     info!(
-                        "operator_1 shares before slashing{:?}",
+                        "operator_1 shares before slashing: {:?}",
                         operator_1_shares_before_slashing
                     );
 
@@ -176,7 +176,7 @@ impl Challenger {
                         .unwrap()
                         .shares;
                     info!(
-                        "operator_2 shares before slashing{:?}",
+                        "operator_2 shares before slashing: {:?}",
                         operator_2_shares_before_slashing
                     );
 
@@ -189,7 +189,7 @@ impl Challenger {
                         .unwrap()
                         .shares;
                     info!(
-                        "operator_1 shares after slashing{:?}",
+                        "operator_1 shares after slashing: {:?}",
                         operator_1_shares_after_slashing
                     );
                     let operator_2_shares_after_slashing = delegation_manager_contract
@@ -199,7 +199,7 @@ impl Challenger {
                         .unwrap()
                         .shares;
                     info!(
-                        "operator_2 shares after slashing{:?}",
+                        "operator_2 shares after slashing: {:?}",
                         operator_2_shares_after_slashing
                     );
                     return Ok(());

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
 
         let mut incredible_config: IncredibleConfig =
             toml::from_str(INCREDIBLE_CONFIG_FILE).unwrap();
-        incredible_config.set_aggregator_ip_address("127.0.0.1:8081".to_string());
+        incredible_config.set_aggregator_ip_address("127.0.0.1:8082".to_string());
         incredible_config.set_registry_coordinator_addr(
             get_incredible_squaring_registry_coordinator()
                 .await


### PR DESCRIPTION
This PR adds a struct `RPCRequest` to be used for parsing the parameters in `start_server`. Now we utilize the params field to store the `SignedTaskResponse`. 

After fixing this, there was another issue with the address when try to initialize the other aggregator server:

```
`thread 'tests::run_tests_in_order' panicked at /Users/damiramirez/eigen/incredible-squaring-avs-rs/crates/aggregator/src/lib.rs:266:14: 
called Result::unwrap() on an Err value: Os { code: 48, kind: AddrInUse, message: "Address already in use" }`
```

We fixed this by changing the aggregator server address from `127.0.0.1:8081` to `127.0.0.1:8082`.